### PR TITLE
refactor: embed migration and seeder data; remove runtime irbac.sql dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,9 @@ Core dari [Codeigniter 3](https://github.com/bcit-ci/CodeIgniter) yg sudah diuba
 * Sesuaikan koneksi db anda di file tersebut
 * (Tambahan) Saya sarankan untuk akses file dengan menggunakan fitur [vhost](https://www.cloudways.com/blog/configure-virtual-host-on-windows-10-for-wordpress/)
 
+
+## Dokumentasi
+- Panduan teknis lengkap: [`docs/CORE_IRBAC_GUIDE.md`](docs/CORE_IRBAC_GUIDE.md)
+
 ## Lisensi
 [MIT](https://choosealicense.com/licenses/mit/)

--- a/application/controllers/CommandsController.php
+++ b/application/controllers/CommandsController.php
@@ -1,0 +1,45 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class CommandsController extends CI_Controller
+{
+    public function __construct()
+    {
+        parent::__construct();
+
+        if (!$this->input->is_cli_request()) {
+            show_error('Endpoint ini hanya bisa dijalankan melalui CLI.', 403);
+        }
+
+        $this->load->database();
+    }
+
+    public function actionMigrate()
+    {
+        $this->config->set_item('migration_enabled', TRUE);
+        $this->load->library('migration');
+
+        if ($this->migration->latest() === false) {
+            echo 'Migration gagal: ' . $this->migration->error_string() . PHP_EOL;
+            return;
+        }
+
+        echo 'Migration berhasil dijalankan ke versi terbaru.' . PHP_EOL;
+    }
+
+    public function actionSeed()
+    {
+        $this->load->library('Seeder');
+        $this->seeder->call('InitialSeeder');
+
+        echo 'Seeder InitialSeeder berhasil dijalankan.' . PHP_EOL;
+    }
+
+    public function actionMigrateAndSeed()
+    {
+        $this->actionMigrate();
+        $this->actionSeed();
+
+        echo 'Migration + seeder selesai.' . PHP_EOL;
+    }
+}

--- a/application/libraries/Seeder.php
+++ b/application/libraries/Seeder.php
@@ -1,0 +1,37 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Seeder
+{
+    /** @var CI_Controller */
+    protected $CI;
+
+    public function __construct()
+    {
+        $this->CI =& get_instance();
+        $this->CI->load->database();
+    }
+
+    /**
+     * @param string $seeder
+     * @return void
+     */
+    public function call($seeder)
+    {
+        $path = APPPATH . 'seeders/' . $seeder . '.php';
+
+        if (!is_file($path)) {
+            show_error('Seeder tidak ditemukan: ' . $seeder, 500);
+        }
+
+        require_once $path;
+
+        $instance = new $seeder();
+
+        if (!method_exists($instance, 'run')) {
+            show_error('Method run() tidak ditemukan pada seeder: ' . $seeder, 500);
+        }
+
+        $instance->run();
+    }
+}

--- a/application/migrations/20260206090000_init_irbac_schema.php
+++ b/application/migrations/20260206090000_init_irbac_schema.php
@@ -1,0 +1,217 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Init_irbac_schema extends CI_Migration
+{
+    /** @var array<int, string> */
+    private $createStatements = [
+        'CREATE TABLE `sys_allowed`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `allowed` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 14 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `sys_audit_trails`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `event` enum(\'insert\',\'update\',\'delete\') CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `table_name` varchar(128) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `old_values` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NULL,
+  `new_values` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `url` varchar(255) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `name` varchar(128) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `ip_address` varchar(45) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `user_agent` varchar(255) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 1 CHARACTER SET = latin1 COLLATE = latin1_swedish_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `sys_auth_assignment`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `auth_item_id` int NULL DEFAULT NULL,
+  `group_id` int NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE,
+  INDEX `fk_auth_assignment_1`(`auth_item_id` ASC) USING BTREE,
+  INDEX `fk_auth_assignment_2`(`group_id` ASC) USING BTREE,
+  CONSTRAINT `sys_auth_assignment_ibfk_1` FOREIGN KEY (`auth_item_id`) REFERENCES `sys_auth_item` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `sys_auth_assignment_ibfk_2` FOREIGN KEY (`group_id`) REFERENCES `tbl_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE = InnoDB AUTO_INCREMENT = 144 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `sys_auth_item`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL,
+  `type` int NULL DEFAULT NULL COMMENT \'1 = routes; 2 = permission\',
+  `description` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL,
+  `created_at` datetime NULL DEFAULT NULL,
+  `created_by` int NULL DEFAULT NULL,
+  `updated_at` datetime NULL DEFAULT NULL,
+  `updated_by` int NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 286 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `sys_auth_item_child`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `parent` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL,
+  `child` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 318 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `tbl_group`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `group_code` varchar(64) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
+  `label` varchar(64) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
+  `desc` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL,
+  `parent_id` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL,
+  `url` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL,
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 10 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `tbl_group_user`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `group_id` int NOT NULL,
+  PRIMARY KEY (`id`) USING BTREE,
+  INDEX `fk_user_id`(`user_id` ASC) USING BTREE,
+  INDEX `fk_group_id`(`group_id` ASC) USING BTREE,
+  CONSTRAINT `tbl_group_user_ibfk_1` FOREIGN KEY (`group_id`) REFERENCES `tbl_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `tbl_group_user_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `tbl_user` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE = InnoDB AUTO_INCREMENT = 4257 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `tbl_menu`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `label` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL,
+  `description` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL,
+  `menu_custom` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL,
+  `menu_type` varchar(32) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
+  `menu_parent` int NULL DEFAULT NULL,
+  `menu_order` int NULL DEFAULT NULL,
+  `menu_url` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL,
+  `class` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL,
+  `status` int NULL DEFAULT NULL,
+  `level` int NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE,
+  INDEX `menu_type`(`menu_type` ASC) USING BTREE,
+  CONSTRAINT `tbl_menu_ibfk_1` FOREIGN KEY (`menu_type`) REFERENCES `tbl_menu_type` (`menu_type`) ON DELETE RESTRICT ON UPDATE RESTRICT
+) ENGINE = InnoDB AUTO_INCREMENT = 51 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `tbl_menu_group`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `menu_id` int NULL DEFAULT NULL,
+  `group_id` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE,
+  INDEX `menu_id`(`menu_id` ASC) USING BTREE,
+  CONSTRAINT `tbl_menu_group_ibfk_1` FOREIGN KEY (`menu_id`) REFERENCES `tbl_menu` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT
+) ENGINE = InnoDB AUTO_INCREMENT = 6320 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `tbl_menu_type`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `menu_type` varchar(32) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
+  `title` varchar(50) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
+  `description` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL,
+  PRIMARY KEY (`id`) USING BTREE,
+  UNIQUE INDEX `menu_type`(`menu_type` ASC) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 2 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `tbl_notifikasi`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `content` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL,
+  `to` int NULL DEFAULT NULL,
+  `is_read` int NULL DEFAULT 0 COMMENT \'0 = Belum; 1 = Dibaca\',
+  `redirect_url` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT \'Url yg akan me-redirect jika notifikasi di-klik\',
+  `priority` varchar(30) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT \'Simpan class untuk ubah warna berdasarkan prioritas\',
+  `created_at` datetime NULL DEFAULT NULL,
+  `triggered_by` int NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 1 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `tbl_user`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `username` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL COMMENT \'Kalau boleh username menggunakan NIP\',
+  `password` varchar(75) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `auth_key` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL COMMENT \'Untuk kebutuhan kode unik aktivasi akun via email atau bisa juga untuk simpan API Key\',
+  `reset_token` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL COMMENT \'Untuk kebutuhan kode unik ketika reset password\',
+  `email` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `status` int NOT NULL DEFAULT 0 COMMENT \'0=inactive; 1=active\',
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp ON UPDATE CURRENT_TIMESTAMP,
+  `created_by` int NULL DEFAULT NULL,
+  `updated_at` datetime NULL DEFAULT NULL,
+  `updated_by` int NULL DEFAULT NULL,
+  `deleted_at` datetime NULL DEFAULT NULL,
+  `deleted_by` int NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE,
+  UNIQUE INDEX `username`(`username` ASC) USING BTREE,
+  INDEX `created_by`(`created_by` ASC) USING BTREE,
+  INDEX `updated_by`(`updated_by` ASC) USING BTREE,
+  INDEX `deleted_by`(`deleted_by` ASC) USING BTREE,
+  CONSTRAINT `tbl_user_ibfk_1` FOREIGN KEY (`created_by`) REFERENCES `tbl_user` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT,
+  CONSTRAINT `tbl_user_ibfk_2` FOREIGN KEY (`updated_by`) REFERENCES `tbl_user` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT,
+  CONSTRAINT `tbl_user_ibfk_3` FOREIGN KEY (`deleted_by`) REFERENCES `tbl_user` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT
+) ENGINE = InnoDB AUTO_INCREMENT = 1714 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = DYNAMIC;',
+        'CREATE TABLE `tbl_user_detail`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `nik` varchar(25) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `nama_depan` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `nama_tengah` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `nama_belakang` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `tempat_lahir` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `tanggal_gabung` date NULL DEFAULT NULL,
+  `tanggal_selesai` date NULL DEFAULT NULL,
+  `job_title` varchar(75) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `tanggal_lahir` date NULL DEFAULT NULL,
+  `agama` enum(\'islam\',\'kristen_protestan\',\'hindu\',\'buddha\',\'katolik\',\'kong_hu_cu\') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL COMMENT \'Kalau ada kemungkinan ditambah, bisa dibuatkan table sendiri\',
+  `jenis_kelamin` enum(\'p\',\'w\') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `status_perkawinan` enum(\'0\',\'1\',\'2\') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT \'0\' COMMENT \'0 = single; 1 = married; 2 = divorce\',
+  `pddk_terakhir` varchar(5) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `alamat` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL COMMENT \'Nantinya akan dibuat data json {jalan:,kota:}\',
+  `kota` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `provinsi` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `kode_pos` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `telepon` varchar(15) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `profile_pic` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp ON UPDATE CURRENT_TIMESTAMP,
+  `created_by` int NULL DEFAULT NULL,
+  `updated_at` datetime NULL DEFAULT NULL,
+  `updated_by` int NULL DEFAULT NULL,
+  `deleted_at` datetime NULL DEFAULT NULL,
+  `deleted_by` int NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE,
+  INDEX `user_id`(`user_id` ASC) USING BTREE,
+  INDEX `created_by`(`created_by` ASC) USING BTREE,
+  INDEX `updated_by`(`updated_by` ASC) USING BTREE,
+  INDEX `deleted_by`(`deleted_by` ASC) USING BTREE,
+  CONSTRAINT `tbl_user_detail_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `tbl_user` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT,
+  CONSTRAINT `tbl_user_detail_ibfk_4` FOREIGN KEY (`created_by`) REFERENCES `tbl_user` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT `tbl_user_detail_ibfk_5` FOREIGN KEY (`updated_by`) REFERENCES `tbl_user` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT `tbl_user_detail_ibfk_6` FOREIGN KEY (`deleted_by`) REFERENCES `tbl_user` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT
+) ENGINE = InnoDB AUTO_INCREMENT = 1592 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = DYNAMIC;',
+    ];
+
+    /** @var array<int, string> */
+    private $tables = [
+        'sys_allowed',
+        'sys_audit_trails',
+        'sys_auth_assignment',
+        'sys_auth_item',
+        'sys_auth_item_child',
+        'tbl_group',
+        'tbl_group_user',
+        'tbl_menu',
+        'tbl_menu_group',
+        'tbl_menu_type',
+        'tbl_notifikasi',
+        'tbl_user',
+        'tbl_user_detail',
+    ];
+
+    public function up()
+    {
+        $this->db->query('SET FOREIGN_KEY_CHECKS = 0');
+
+        foreach ($this->createStatements as $statement) {
+            $this->db->query($statement);
+        }
+
+        $this->db->query('SET FOREIGN_KEY_CHECKS = 1');
+    }
+
+    public function down()
+    {
+        $this->db->query('SET FOREIGN_KEY_CHECKS = 0');
+
+        foreach (array_reverse($this->tables) as $table) {
+            $this->dbforge->drop_table($table, true);
+        }
+
+        $this->db->query('SET FOREIGN_KEY_CHECKS = 1');
+    }
+}

--- a/application/seeders/InitialSeeder.php
+++ b/application/seeders/InitialSeeder.php
@@ -1,0 +1,258 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class InitialSeeder
+{
+    /** @var CI_Controller */
+    private $CI;
+
+    /** @var array<int, string> */
+    private $truncateOrder = [
+        'tbl_user_detail',
+        'tbl_notifikasi',
+        'tbl_menu_group',
+        'tbl_menu',
+        'tbl_group_user',
+        'sys_auth_item_child',
+        'sys_auth_assignment',
+        'sys_auth_item',
+        'sys_allowed',
+        'tbl_menu_type',
+        'tbl_group',
+        'sys_audit_trails',
+        'tbl_user',
+    ];
+
+    /** @var array<int, string> */
+    private $insertStatements = [
+        'INSERT INTO `sys_allowed` VALUES (6, \'site/logout\');',
+        'INSERT INTO `sys_allowed` VALUES (9, \'site/login\');',
+        'INSERT INTO `sys_allowed` VALUES (10, \'site/google-auth\');',
+        'INSERT INTO `sys_allowed` VALUES (11, \'site/not-found\');',
+        'INSERT INTO `sys_allowed` VALUES (13, \'site/refresh-csrf\');',
+        'INSERT INTO `sys_auth_assignment` VALUES (3, 32, 1);',
+        'INSERT INTO `sys_auth_assignment` VALUES (4, 109, 1);',
+        'INSERT INTO `sys_auth_item` VALUES (32, \'rbac-permission\', 2, \'Permission untuk routes Role Base Access Control\', \'2020-10-21 10:19:48\', 1, \'2020-10-30 13:31:10\', 1);',
+        'INSERT INTO `sys_auth_item` VALUES (48, \'rbac/menu/index\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (49, \'rbac/menu/hapus\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (50, \'rbac/menu/list-menu\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (52, \'rbac/user/index\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (53, \'rbac/user/get-data\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (54, \'rbac/user/create\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (55, \'rbac/user/detail\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (56, \'rbac/user/simpan-detail\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (57, \'rbac/user/edit\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (58, \'rbac/user/hapus\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (59, \'rbac/user/get-department\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (61, \'rbac/group/index\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (62, \'rbac/group/detail\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (63, \'rbac/group/get-data\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (64, \'rbac/group/simpan\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (65, \'rbac/group/hapus\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (67, \'rbac/route/index\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (68, \'rbac/route/create\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (69, \'rbac/route/assign\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (70, \'rbac/route/remove\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (71, \'rbac/route/refresh\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (73, \'rbac/allowed/index\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (74, \'rbac/allowed/create\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (75, \'rbac/allowed/assign\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (76, \'rbac/allowed/remove\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (77, \'rbac/allowed/refresh\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (79, \'rbac/permission/index\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (80, \'rbac/permission/detail\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (81, \'rbac/permission/get-data\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (82, \'rbac/permission/simpan\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (83, \'rbac/permission/hapus\', 1, NULL, \'2020-10-30 13:23:51\', 1, \'2020-10-30 13:23:51\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (87, \'rbac/menu/index\', 1, NULL, \'2020-10-31 04:34:33\', 1, \'2020-10-31 04:34:33\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (88, \'site/index\', 1, NULL, \'2020-11-15 11:57:23\', 1, \'2020-11-15 11:57:23\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (89, \'site/lock\', 1, NULL, \'2020-11-15 11:57:23\', 1, \'2020-11-15 11:57:23\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (92, \'rbac/menu\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (93, \'rbac/user\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (94, \'rbac/group\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (95, \'rbac/route\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (96, \'rbac/allowed\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (97, \'rbac/permission\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (98, \'rbac/permission/view\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (99, \'rbac/permission/assign\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (100, \'rbac/permission/remove\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (101, \'rbac/permission/refresh\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (102, \'rbac/assignment\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (103, \'rbac/assignment/index\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (104, \'rbac/assignment/get-data\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (105, \'rbac/assignment/view\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (106, \'rbac/assignment/assign\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (107, \'rbac/assignment/remove\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (108, \'rbac/assignment/refresh\', 1, NULL, \'2020-11-15 11:57:30\', 1, \'2020-11-15 11:57:30\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (109, \'all-user-permission\', 2, \'Permission that accessible by all user\', \'2020-11-22 08:37:00\', 1, \'2020-11-22 08:37:00\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (110, \'profil/ubah-password\', 1, NULL, \'2021-06-03 23:39:18\', 1, \'2021-06-03 23:39:18\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (153, \'rbac/user/get-atasan\', 1, NULL, \'2021-06-03 23:39:18\', 1, \'2021-06-03 23:39:18\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (154, \'rbac/user/get-grade\', 1, NULL, \'2021-06-03 23:39:18\', 1, \'2021-06-03 23:39:18\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (155, \'rbac/user/get-designation\', 1, NULL, \'2021-06-03 23:39:18\', 1, \'2021-06-03 23:39:18\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (156, \'rbac/user/get-kelas-jabatan\', 1, NULL, \'2021-06-03 23:39:18\', 1, \'2021-06-03 23:39:18\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (157, \'rbac/user/get-golongan\', 1, NULL, \'2021-06-03 23:39:18\', 1, \'2021-06-03 23:39:18\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (204, \'notifikasi/index\', 1, NULL, \'2021-06-03 23:39:18\', 1, \'2021-06-03 23:39:18\', NULL);',
+        'INSERT INTO `sys_auth_item` VALUES (205, \'notifikasi/read\', 1, NULL, \'2021-06-03 23:39:18\', 1, \'2021-06-03 23:39:18\', NULL);',
+        'INSERT INTO `sys_auth_item_child` VALUES (3, \'rbac-permission\', \'rbac/menu/hapus\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (4, \'rbac-permission\', \'rbac/menu/list-menu\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (5, \'rbac-permission\', \'rbac/user/index\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (6, \'rbac-permission\', \'rbac/user/get-data\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (7, \'rbac-permission\', \'rbac/user/create\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (8, \'rbac-permission\', \'rbac/user/detail\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (9, \'rbac-permission\', \'rbac/user/simpan-detail\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (10, \'rbac-permission\', \'rbac/user/edit\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (11, \'rbac-permission\', \'rbac/user/hapus\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (12, \'rbac-permission\', \'rbac/user/get-department\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (13, \'rbac-permission\', \'rbac/menu/index\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (14, \'rbac-permission\', \'rbac/group/index\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (15, \'rbac-permission\', \'rbac/group/detail\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (16, \'rbac-permission\', \'rbac/group/get-data\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (17, \'rbac-permission\', \'rbac/group/simpan\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (18, \'rbac-permission\', \'rbac/group/hapus\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (19, \'rbac-permission\', \'rbac/route/index\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (20, \'rbac-permission\', \'rbac/route/create\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (21, \'rbac-permission\', \'rbac/route/assign\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (22, \'rbac-permission\', \'rbac/route/remove\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (23, \'rbac-permission\', \'rbac/route/refresh\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (24, \'rbac-permission\', \'rbac/allowed/index\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (25, \'rbac-permission\', \'rbac/allowed/create\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (26, \'rbac-permission\', \'rbac/allowed/assign\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (27, \'rbac-permission\', \'rbac/allowed/remove\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (28, \'rbac-permission\', \'rbac/allowed/refresh\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (29, \'rbac-permission\', \'rbac/permission/index\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (30, \'rbac-permission\', \'rbac/permission/detail\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (31, \'rbac-permission\', \'rbac/permission/get-data\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (32, \'rbac-permission\', \'rbac/permission/simpan\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (33, \'rbac-permission\', \'rbac/permission/hapus\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (34, \'rbac-permission\', \'rbac/permission/view\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (35, \'rbac-permission\', \'rbac/permission/assign\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (36, \'rbac-permission\', \'rbac/menu\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (37, \'rbac-permission\', \'rbac/user\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (38, \'rbac-permission\', \'rbac/group\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (39, \'rbac-permission\', \'rbac/route\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (40, \'rbac-permission\', \'rbac/allowed\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (41, \'rbac-permission\', \'rbac/permission\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (42, \'rbac-permission\', \'rbac/permission/assign\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (43, \'rbac-permission\', \'rbac/permission/remove\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (44, \'rbac-permission\', \'rbac/permission/refresh\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (45, \'rbac-permission\', \'rbac/assignment\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (46, \'rbac-permission\', \'rbac/assignment/index\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (47, \'rbac-permission\', \'rbac/assignment/get-data\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (48, \'rbac-permission\', \'rbac/assignment/view\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (49, \'rbac-permission\', \'rbac/assignment/assign\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (50, \'rbac-permission\', \'rbac/assignment/remove\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (51, \'rbac-permission\', \'rbac/assignment/refresh\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (135, \'rbac-permission\', \'rbac/user/get-atasan\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (136, \'rbac-permission\', \'rbac/user/get-grade\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (137, \'rbac-permission\', \'rbac/user/get-designation\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (138, \'rbac-permission\', \'rbac/user/get-kelas-jabatan\');',
+        'INSERT INTO `sys_auth_item_child` VALUES (139, \'rbac-permission\', \'rbac/user/get-golongan\');',
+        'INSERT INTO `tbl_group` VALUES (1, \'administrator\', \'Administrator\', \'Jenis grup yg memiliki hak akses penuh terhadap sistem\', \'[1]\', \'/site/index\');',
+        'INSERT INTO `tbl_group_user` VALUES (2279, 1, 1);',
+        'INSERT INTO `tbl_menu` VALUES (5, \'Pengaturan\', \'\', \'1\', \'backend-menu\', 0, 1, \'#\', \'fas fa-cogs\', NULL, 1);',
+        'INSERT INTO `tbl_menu` VALUES (6, \'Manajemen User\', \'\', \'1\', \'backend-menu\', 5, 1, \'#\', \'fas fa-users\', NULL, 2);',
+        'INSERT INTO `tbl_menu` VALUES (7, \'Manajemen Menu\', \'\', \'1\', \'backend-menu\', 5, 2, \'/rbac/menu\', \'fas fa-sliders-h\', NULL, 2);',
+        'INSERT INTO `tbl_menu` VALUES (17, \'Dashboard\', \'\', \'1\', \'backend-menu\', 0, 0, \'/site\', \'fas fa-tachometer-alt\', NULL, 1);',
+        'INSERT INTO `tbl_menu` VALUES (30, \'Access Control\', \'\', \'1\', \'backend-menu\', 5, 0, \'#\', \'fas fa-shield-alt\', NULL, 2);',
+        'INSERT INTO `tbl_menu` VALUES (31, \'Allowed\', \'\', \'1\', \'backend-menu\', 30, 0, \'/rbac/allowed\', \'\', NULL, 3);',
+        'INSERT INTO `tbl_menu` VALUES (32, \'Route\', \'\', \'1\', \'backend-menu\', 30, 1, \'/rbac/route\', \'\', NULL, 3);',
+        'INSERT INTO `tbl_menu` VALUES (33, \'Permission\', \'\', \'1\', \'backend-menu\', 30, 2, \'/rbac/permission\', \'\', NULL, 3);',
+        'INSERT INTO `tbl_menu` VALUES (34, \'Assignment\', \'\', \'1\', \'backend-menu\', 30, 3, \'/rbac/assignment\', \'\', NULL, 3);',
+        'INSERT INTO `tbl_menu` VALUES (35, \'User\', \'\', \'1\', \'backend-menu\', 6, 0, \'/rbac/user\', \'\', NULL, 3);',
+        'INSERT INTO `tbl_menu` VALUES (36, \'Group\', \'\', \'1\', \'backend-menu\', 6, 1, \'/rbac/group\', \'\', NULL, 3);',
+        'INSERT INTO `tbl_menu_group` VALUES (6297, 17, \'1\');',
+        'INSERT INTO `tbl_menu_group` VALUES (6304, 5, \'1\');',
+        'INSERT INTO `tbl_menu_group` VALUES (6307, 30, \'1\');',
+        'INSERT INTO `tbl_menu_group` VALUES (6308, 31, \'1\');',
+        'INSERT INTO `tbl_menu_group` VALUES (6309, 32, \'1\');',
+        'INSERT INTO `tbl_menu_group` VALUES (6310, 33, \'1\');',
+        'INSERT INTO `tbl_menu_group` VALUES (6311, 34, \'1\');',
+        'INSERT INTO `tbl_menu_group` VALUES (6312, 6, \'1\');',
+        'INSERT INTO `tbl_menu_group` VALUES (6315, 35, \'1\');',
+        'INSERT INTO `tbl_menu_group` VALUES (6318, 36, \'1\');',
+        'INSERT INTO `tbl_menu_group` VALUES (6319, 7, \'1\');',
+        'INSERT INTO `tbl_menu_type` VALUES (1, \'backend-menu\', \'Menu Utama\', \'Menu utama aplikasi HRIS\');',
+    ];
+
+    public function __construct()
+    {
+        $this->CI =& get_instance();
+        $this->CI->load->database();
+    }
+
+    public function run()
+    {
+        $this->CI->db->trans_begin();
+        $this->CI->db->query('SET FOREIGN_KEY_CHECKS = 0');
+
+        foreach ($this->truncateOrder as $table) {
+            $this->CI->db->query('TRUNCATE TABLE `' . $table . '`');
+        }
+
+        foreach ($this->insertStatements as $statement) {
+            $this->CI->db->query($statement);
+        }
+
+        $this->seedDefaultAdmin();
+
+        $this->CI->db->query('SET FOREIGN_KEY_CHECKS = 1');
+
+        if ($this->CI->db->trans_status() === false) {
+            $this->CI->db->trans_rollback();
+            show_error('Seeder gagal dijalankan.', 500);
+        }
+
+        $this->CI->db->trans_commit();
+    }
+
+    private function seedDefaultAdmin()
+    {
+        $hash = password_hash('4dm1n-Rbac', PASSWORD_BCRYPT);
+
+        $this->CI->db->insert('tbl_user', [
+            'id' => 1,
+            'username' => 'admin',
+            'password' => $hash,
+            'auth_key' => null,
+            'reset_token' => null,
+            'email' => '',
+            'status' => 1,
+            'created_at' => '2024-01-27 20:59:25',
+            'created_by' => null,
+            'updated_at' => '2024-01-27 20:59:25',
+            'updated_by' => 1,
+            'deleted_at' => null,
+            'deleted_by' => null,
+        ]);
+
+        $this->CI->db->insert('tbl_user_detail', [
+            'id' => 1,
+            'user_id' => 1,
+            'nik' => '',
+            'nama_depan' => 'Administrator',
+            'nama_tengah' => '',
+            'nama_belakang' => 'System',
+            'tempat_lahir' => '',
+            'tanggal_gabung' => '1993-08-15',
+            'tanggal_selesai' => '0000-00-00',
+            'job_title' => '',
+            'tanggal_lahir' => '1997-06-19',
+            'agama' => '',
+            'jenis_kelamin' => 'p',
+            'status_perkawinan' => '0',
+            'pddk_terakhir' => '1',
+            'alamat' => '',
+            'kota' => null,
+            'provinsi' => null,
+            'kode_pos' => null,
+            'telepon' => '',
+            'profile_pic' => './web/uploads/profile/Foto_Profil_1.png',
+            'created_at' => '2024-02-20 15:49:55',
+            'created_by' => 1,
+            'updated_at' => null,
+            'updated_by' => null,
+            'deleted_at' => null,
+            'deleted_by' => null,
+        ]);
+    }
+}

--- a/docs/CORE_IRBAC_GUIDE.md
+++ b/docs/CORE_IRBAC_GUIDE.md
@@ -1,0 +1,323 @@
+# CORE IRBAC Documentation
+
+Dokumentasi ini dibuat untuk onboarding developer baru dan sebagai referensi teknis saat mengembangkan fitur di repository `core-irbac`.
+
+---
+
+## 1) Gambaran Umum Repository
+
+- **Framework:** CodeIgniter 3.
+- **Arsitektur:** HMVC (Modular Extensions / MX).
+- **UI:** AdminLTE.
+- **Auth:** Session-based auth untuk web + JWT untuk API.
+- **Authorization:** RBAC (role-based access control) berbasis route.
+
+Referensi struktur utama:
+
+```text
+├── application/     # Core aplikasi CodeIgniter
+├── system/          # System files CodeIgniter
+├── web/             # Web assets (CSS, JS, images)
+├── index.php        # Entry point
+├── irbac.sql        # Database schema + seed
+└── .env.example     # Environment config template
+```
+
+---
+
+## 2) Bootstrapping dan Entry Point
+
+### 2.1 Alur startup
+
+1. Request masuk ke `index.php`.
+2. CI environment diset dari `$_SERVER['CI_ENV']` (default `development`).
+3. Dotenv loader dijalankan untuk membaca file `.env`.
+4. Framework CodeIgniter diboot melalui `system/core/CodeIgniter.php`.
+
+### 2.2 Konfigurasi environment
+
+Pastikan `.env` diisi berdasarkan `.env.example`, terutama:
+
+- `APP_*` metadata aplikasi.
+- `DB_*` koneksi database.
+- `GOOGLE_ID`, `GOOGLE_SECRET` untuk OAuth.
+- `JWT_ACCESS_TOKEN`, `JWT_REFRESH_TOKEN` untuk API JWT.
+
+---
+
+## 3) Arsitektur Aplikasi
+
+### 3.1 HMVC
+
+Project menggunakan `MY_Router` yang mewarisi `MX_Router`. Artinya controller bisa berada di:
+
+- `application/controllers/*` (global)
+- `application/modules/<module>/controllers/*` (modular)
+
+Modul utama saat ini: `rbac`.
+
+### 3.2 Route organization
+
+Route dibagi menjadi beberapa file:
+
+- `application/config/routes.php` → route utama aplikasi.
+- `application/config/rbac.php` → route modul RBAC.
+- `application/config/api.php` → route API.
+
+`routes.php` melakukan `require_once` ke `api.php` dan `rbac.php`.
+
+### 3.3 Pola naming routing (wajib konsisten)
+
+#### Controller
+- Pattern: `{Name}Controller.php`
+- Contoh: `SiteController`, `UserController`, `PermissionController`
+
+#### Action method
+- Pattern: `action{MethodName}`
+- Contoh: `actionIndex`, `actionCreate`, `actionSimpan`, `actionGetData`
+
+#### URL route
+- Pattern: `kebab-case`
+- Contoh: `site/login`, `profil/simpan-info-personal`, `rbac/user/get-data`
+
+#### HTTP method
+- Default route = GET
+- POST route harus eksplisit: `['post']`
+
+---
+
+## 4) Authentication dan Authorization
+
+### 4.1 Session auth (web)
+
+### Login flow (`SiteController::actionLogin`)
+
+1. User membuka `/site/login`.
+2. Form POST diproses oleh model `Formlogin`.
+3. `Formlogin` melakukan validasi user + `password_verify()`.
+4. Jika sukses, session diset:
+   - `status_login`
+   - `identity`
+   - `menus`
+   - `group_id`
+   - `detail_identity`
+
+### Lock/unlock flow
+
+- `/site/lock` menset status login ke `locked`.
+- Unlock membutuhkan verifikasi password user saat ini.
+
+### Google OAuth flow
+
+- Route: `/site/google-auth`.
+- Menggunakan `google/apiclient`.
+- Jika email match user internal, session login dibentuk seperti flow normal.
+
+### 4.2 Route guard via hooks
+
+Hook aktif melalui `enable_hooks = TRUE`:
+
+- `AuthHelper::checkLogin` (post_controller_constructor)
+- `AuthHelper::checkPermission` (post_controller)
+- `CommonHook::setNotification` (post_controller)
+
+Aturan utamanya:
+
+1. Jika route ada di `sys_allowed` → bypass login/permission.
+2. Jika tidak, user harus login.
+3. Setelah login, route harus ada pada daftar route yang diizinkan berdasarkan group.
+4. Jika gagal: redirect login / lock / 401 / 404 sesuai kondisi.
+
+### 4.3 JWT auth (API)
+
+`MY_Controller` dipakai untuk endpoint API yang memerlukan bearer token:
+
+- Set CORS header.
+- Ambil bearer token.
+- Decode JWT (`HS512`) dan validasi claim (`iss`, `nbf`, `exp`).
+- Jika valid, data user disimpan ke session `identity` untuk kebutuhan `blameable`.
+
+---
+
+## 5) RBAC Module
+
+Lokasi: `application/modules/rbac/`.
+
+### 5.1 Controller utama RBAC
+
+- `MenuController`
+- `UserController`
+- `GroupController`
+- `RouteController`
+- `AllowedController`
+- `PermissionController`
+- `AssignmentController`
+
+### 5.2 Konsep RBAC di project ini
+
+- **Allowed route:** route publik yang tidak butuh login (`sys_allowed`).
+- **Route item:** route yang dapat diassign (`sys_auth_item` dengan type route).
+- **Permission item:** permission yang mengelompokkan route (`sys_auth_item` dengan type permission).
+- **Assignment:** permission ke group (`sys_auth_assignment`).
+- **Child mapping:** relasi permission ↔ route (`sys_auth_item_child`).
+
+---
+
+## 6) Layout, View, dan UI Convention
+
+### 6.1 Layout Library
+
+`application/libraries/Layout.php` mengatur render dengan pola:
+
+```php
+$this->layout->layout = 'main';
+$this->layout->title = 'Page Title';
+$this->layout->view_js = '_partial/index_js';
+$this->layout->view_css = '_partial/index_css';
+$this->layout->render('index', $data);
+```
+
+### 6.2 Layout utama
+
+- `application/views/layouts/main.php` untuk halaman setelah login.
+- Sidebar menu dirender dinamis via `Menuhelper` berdasarkan session `menus` + `group_id`.
+
+### 6.3 Konvensi folder view
+
+Jika controller `SiteController` memanggil `render('index')`, maka default view path:
+
+- `application/views/site/index.php`
+
+Partial yang lazim dipakai:
+
+- `application/views/site/_partial/index_js.php`
+- `application/views/site/_partial/index_css.php`
+
+---
+
+## 7) Custom ORM & Model Layer
+
+### 7.1 Base classes
+
+- `MY_Orm` (adaptasi dari yidas model): ActiveRecord style, relation helper (`hasOne`, `hasMany`), timestamps, blameable, soft delete.
+- `MY_Model`: utility query umum (`get`, `getAll`, `delete`, datatables helpers).
+
+### 7.2 Form model vs table model
+
+- **Table model**: representasi 1 tabel (contoh: `User`, `Group`, `Notifikasi`).
+- **Form model**: model untuk validasi/input flow tanpa representasi langsung tabel (contoh: `Formlogin`, `FormChangePassword`).
+
+---
+
+## 8) Mapping Database → Model (1 table 1 model)
+
+> Catatan: Beberapa model berbagi tabel yang sama untuk memisahkan concern bisnis (contoh: `Authitem`, `Routes`, `Permission` semuanya berbasis `sys_auth_item`).
+
+| Tabel | Model utama | Lokasi model | Catatan |
+|---|---|---|---|
+| `tbl_user` | `User` | `application/models/master/User.php` | User account + relation group/detail |
+| `tbl_user_detail` | `Userdetail` | `application/models/transaksi/Userdetail.php` | Profil/detail user |
+| `tbl_group` | `Group` | `application/models/master/Group.php` | Group/role level aplikasi |
+| `tbl_group_user` | `Usergroup` | `application/models/master/Usergroup.php` | Pivot user-group |
+| `tbl_menu` | `Menu` | `application/models/master/Menu.php` | Data menu dinamis |
+| `tbl_menu_group` | `Menugroup` | `application/models/master/Menugroup.php` | Pivot menu-group |
+| `tbl_menu_type` | `Menutype` | `application/models/master/Menutype.php` | Tipe menu |
+| `tbl_notifikasi` | `Notifikasi` | `application/models/Notifikasi.php` | Notifikasi user |
+| `sys_allowed` | `Allowed` | `application/models/rbac/Allowed.php` | Route publik tanpa auth |
+| `sys_auth_assignment` | `Authassignment` | `application/models/rbac/Authassignment.php` | Assignment permission ke group |
+| `sys_auth_item` | `Authitem` | `application/models/rbac/Authitem.php` | Entitas route + permission |
+| `sys_auth_item` | `Routes` | `application/models/rbac/Routes.php` | Operasi route (type route) |
+| `sys_auth_item` | `Permission` | `application/models/rbac/Permission.php` | Operasi permission (type permission) |
+| `sys_auth_item_child` | `Authitemchild` | `application/models/rbac/Authitemchild.php` | Relasi parent-child item |
+
+### 8.1 Tabel yang belum punya model khusus
+
+- `sys_audit_trails` sudah ada di SQL, namun belum ada model aktif khusus di `application/models` saat ini.
+
+---
+
+## 9) Migration & Seeder (CodeIgniter)
+
+Project ini sekarang menyediakan migration dan seeder native CodeIgniter:
+
+- Migration schema: `application/migrations/20260206090000_init_irbac_schema.php`
+- Seeder runner library: `application/libraries/Seeder.php`
+- Initial seeder: `application/seeders/InitialSeeder.php`
+- CLI command: `application/controllers/CommandsController.php`
+
+### 9.1 Menjalankan migration
+
+```bash
+php index.php CommandsController actionMigrate
+```
+
+### 9.2 Menjalankan seeder
+
+```bash
+php index.php CommandsController actionSeed
+```
+
+### 9.3 Menjalankan migration + seeder sekaligus
+
+```bash
+php index.php CommandsController actionMigrateAndSeed
+```
+
+### 9.4 Default credential seed
+
+Seeder akan membuat user admin default:
+
+- username: `admin`
+- password: `4dm1n-Rbac`
+
+> Catatan: migration dan seeder **tidak bergantung** pada pembacaan file `irbac.sql` saat runtime; schema dan seed statement sudah didefinisikan langsung di file migration/seeder.
+
+---
+
+## 10) Developer Workflow (fitur baru)
+
+Contoh: menambah modul `Blog`.
+
+1. Buat struktur module:
+   - `application/modules/blog/controllers/BlogController.php`
+   - `application/modules/blog/models/Blog.php`
+   - `application/modules/blog/views/blog/index.php`
+2. Tambah route di `application/config/routes.php` dengan pola `action*`.
+3. Buka `/rbac/route` dan lakukan refresh route.
+4. Buat permission di `/rbac/permission`.
+5. Assign permission ke group di `/rbac/assignment`.
+6. Tambah menu di `/rbac/menu`.
+7. Uji login user dengan group berbeda.
+
+---
+
+## 11) Dokumentasi Otomatis ke Depan (WAJIB)
+
+Agar dokumentasi ini selalu up-to-date, gunakan aturan berikut:
+
+1. **Setiap PR yang menambah/mengubah salah satu dari poin ini wajib update file ini:**
+   - route baru/perubahan route,
+   - model/table baru,
+   - hook/auth flow,
+   - module baru,
+   - perubahan convention.
+2. **Checklist PR wajib** (copy ke deskripsi PR):
+   - [ ] Sudah update `docs/CORE_IRBAC_GUIDE.md`
+   - [ ] Sudah update mapping table-model (jika ada tabel/model baru)
+   - [ ] Sudah update contoh flow jika ada perubahan auth/rbac
+3. **Rule review:** PR tidak boleh di-merge jika checklist dokumentasi tidak terpenuhi.
+
+> Rekomendasi: jadikan poin checklist di atas sebagai bagian template Pull Request tim agar pembaruan dokumentasi berlangsung otomatis sebagai bagian standar proses merge.
+
+---
+
+## 12) Quick Checklist untuk Developer Baru
+
+- [ ] Jalankan `composer install`.
+- [ ] Copy `.env.example` → `.env` dan isi semua variabel penting.
+- [ ] Jalankan migration + seeder via CLI command.
+- [ ] Pastikan route default (`/site`) bisa diakses.
+- [ ] Login menggunakan akun seed data.
+- [ ] Cek menu RBAC (`/rbac/*`) untuk memahami relasi route-permission-group.
+- [ ] Baca ulang section 3, 4, 5, 8 sebelum menambah fitur baru.
+


### PR DESCRIPTION
### Motivation
- Stop relying on `irbac.sql` at runtime because the SQL file will be removed and migration/seeder must be self-contained. 
- Make migrations and seeders deterministic and portable for CLI-driven provisioning without parsing external files.

### Description
- Embedded the full schema `CREATE TABLE` statements into `application/migrations/20260206090000_init_irbac_schema.php` and preserved a reversible `down()` that drops tables in safe order. 
- Embedded seed `INSERT` statements (excluding `tbl_user`/`tbl_user_detail`) into `application/seeders/InitialSeeder.php` and added a manual admin seed that hashes the password for `4dm1n-Rbac`. 
- Added a simple seeder runner `application/libraries/Seeder.php` and CLI controller `application/controllers/CommandsController.php` exposing `actionMigrate`, `actionSeed`, and `actionMigrateAndSeed`. 
- Removed the now-unused `application/libraries/SqlFileParser.php` and updated `docs/CORE_IRBAC_GUIDE.md` to state the migration/seeder are self-contained and to replace the `irbac.sql` import checklist with running the CLI migration/seeder commands. 

### Testing
- Ran PHP syntax checks with `php -l` on the updated files and they reported no syntax errors (success). 
- Verified embedded statement counts with a script that reported `create=13` and `insert=147`, matching expected schema/seed scope (success). 
- Exercised CLI paths by invoking `php index.php CommandsController actionMigrate` and `php index.php CommandsController actionSeed` up to DB initialization, but full execution was blocked by the environment due to missing MySQL socket and PHP/CI deprecation warnings (environment-limited).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69854303b9888331836d825805cb93e9)